### PR TITLE
Do not raise runtime error if group is empty

### DIFF
--- a/N2SNUserTools/ldap.py
+++ b/N2SNUserTools/ldap.py
@@ -258,7 +258,7 @@ class ADObjects(object):
             raise RuntimeError(f"Group name '{group_name}' is not unique. "
                                f"Found groups: {group}")
         elif len(group) == 0:
-            raise RuntimeError(f"Group name '{group_name}' is empty.")
+            return list()
 
         group = group[0]
 


### PR DESCRIPTION
Currently, machine provisioning will fail if any of the default n2sn groups are empty because the n2sn_user_tools role checks the members of each group as a test. The RuntimeError is leading to a failure in ansible which stops provisioning. I believe if we just return an empty list in these cases this will be solved (the downside being that instead of an error message about group being empty, the table will just print without any entries.)