### PR TITLE
CI: add PyPI release workflow

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,38 @@
+# This workflows will upload a Python Package when a release is created.
+# For more information see:
+# - https://docs.pypi.org/trusted-publishers/adding-a-publisher/
+# - https://github.com/pypa/gh-action-pypi-publish
+
+name: Upload Python Package
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Build package
+        run: |
+          set -vxeuo pipefail
+          python -m pip install --upgrade pip
+          pip install wheel setuptools
+          python setup.py sdist bdist_wheel
+
+      - name: Publish wheels to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: ./dist/


### PR DESCRIPTION
The workflow was taken from https://github.com/NSLS-II/nslsii/blob/master/.github/workflows/publish-pypi.yml with minor tweaks.