### PR TITLE
Fix/align rbac terms

### DIFF
--- a/MIGRATION_PLAN.md
+++ b/MIGRATION_PLAN.md
@@ -1,0 +1,190 @@
+# Migration Plan: `rights` -> `roles` (RBAC terminology consistency)
+
+## Purpose
+
+Bring `N2SNUserTools` and the `n2sn_user_tools` Ansible role into terminology
+consistency with the NSLS-II RBAC documentation
+(`n2sndocs/explanations/security/rbac/intro.md`).
+
+Per the RBAC docs, the AD groups this tool manages (`n2sn-inststaff-*`,
+`n2sn-instusers-*`, `n2sn-analysis-*`, etc.) contain **users directly** and
+follow the **role** naming convention. In the RBAC model these are therefore
+**role groups**, not right groups (right groups contain role groups, never
+users directly, and are named `n2sn-right-<system>-<permission>`).
+
+The tool currently calls these `rights`. This is inconsistent with the docs.
+This plan renames the config key `rights` -> `roles` and the user-facing CLI
+wording `right`/`RIGHT` -> `role`/`ROLE`, using a staged, backward-compatible
+migration so no deployed host is ever left with a tool that cannot read the
+deployed config.
+
+The `LDAPInsufficientAccessRightsResult` ldap3 exception in `cli.py` is a
+*different, correct* use of "rights" (LDAP ACL permissions) and is left
+unchanged.
+
+## Confirmed design decisions
+
+- Rename config key `rights` -> `roles`.
+- Rename user-facing CLI wording `right`/`RIGHT` -> `role`/`ROLE`.
+- **Config parser:** prefer `roles`, fall back to `rights` with a
+  `DeprecationWarning` during the transition. At Stage 6 this becomes a **hard
+  failure** (`rights`-only config raises `RuntimeError`).
+- **CLI wording:** the user-facing positional argument, help text, and output
+  strings switch from `right`/`RIGHT` to `role`/`ROLE`. The positional argument
+  has always taken a *role name* (`staff`, `user`, ...) as its value, never the
+  literal token `right`, and there was never a `--right` flag, so this is a
+  pure wording change with no backward-compatibility concern.
+- **Template dual-write:** use **YAML anchors/aliases**. Each instrument anchors
+  its role mapping under `roles:` and aliases it into `rights:`. PyYAML (the
+  tool's parser, via `yaml.SafeLoader`) fully supports anchors/aliases.
+- `fis` `analysis` typo (`n2sn-analysis-fix` -> `-fis`) already fixed by the
+  repo owner.
+- **Stages 1 and 3 execute in parallel** (no ordering dependency between them).
+
+## Config-parser helper (`cli.py`)
+
+```python
+def get_roles(inst_config):
+    if 'roles' in inst_config:
+        return inst_config['roles']
+    if 'rights' in inst_config:
+        warnings.warn(
+            "The 'rights' key in n2sn_tools.yml is deprecated; rename it to "
+            "'roles'. Support will be removed in a future release.",
+            DeprecationWarning, stacklevel=2)
+        return inst_config['rights']
+    raise RuntimeError("Instrument config missing 'roles' section")
+```
+
+At Stage 6 the `rights` fallback branch is removed and becomes a hard
+`RuntimeError`.
+
+## Template dual-write pattern (`n2sn_tools.yml.j2`)
+
+```yaml
+  amx:
+    name: AMX
+    roles: &amx_roles
+      staff: n2sn-inststaff-amx
+      user: n2sn-instusers-amx
+      analysis: n2sn-analysis-amx
+      guacctrl: n2sn-instusers-guacctrl-amx
+      guacview: n2sn-instusers-guacview-amx
+      nx: n2sn-instusers-nxopen-amx
+    rights: *amx_roles
+```
+
+- 33 unique anchor names: `&<acronym>_roles`.
+- Instrument-specific extra keys (`nyx`: `gp`/`ccp4`/`phenix`/`hkl`;
+  `chx`/`csx`: `offline`; `tst`: commented-out keys) live inside the anchored
+  block and are therefore shared automatically by the alias.
+- At Stage 5, delete the `rights: *<acronym>_roles` lines and drop the
+  `&<acronym>_roles` anchor names, leaving plain `roles:` blocks.
+
+## Affected locations
+
+**`N2SNUserTools/N2SNUserTools/cli.py`:**
+- L109 `groups = config['rights']` -> `get_roles(config)`
+- L166 `inst_config['rights'].keys()` -> `get_roles(inst_config).keys()`
+- L186 `inst_config['rights'][right.lower()]` -> via `get_roles(inst_config)`
+- L145 `--purge` help, L148-150 positional arg/metavar/help,
+  L171-176 local var + validation text, L241-281 output strings
+  -> `role`/`ROLE`
+- L7 `LDAPInsufficientAccessRightsResult` -> **unchanged**
+
+**`N2SNUserTools/README.rst`:** add brief config-schema section documenting
+`roles:` and the `rights:` deprecation.
+
+**`ansible/roles/n2sn_user_tools/templates/n2sn_tools.yml.j2`:** anchor/alias
+dual-write for all 33 instruments.
+
+**`ansible/roles/n2sn_user_tools/tasks/*.yml`:** no change.
+
+## Stages
+
+### Stage 1 || Stage 3 (parallel)
+
+**Stage 1 - `N2SNUserTools` (tool accepts both keys):**
+1. Add `import warnings` + `get_roles()` helper.
+2. Route the three config reads through `get_roles()`.
+3. Rename CLI wording to `role`/`ROLE` (positional argument value has always
+   been a role name, so this is a pure wording change).
+4. Add README config section.
+5. Release new RPM.
+
+**Stage 3 - `ansible` role (template dual-write):**
+- Convert template to anchor/alias dual-write; deploy fleet-wide.
+
+*Safe in parallel:* dual-key config reads fine on both old (`rights`) and new
+(`roles`) tools; the new tool also reads legacy `rights`-only configs.
+
+### Stage 2 - Roll out new tool everywhere
+- Bump the package pin; run playbook fleet-wide.
+- Confirm `n2sn_list_users` smoke test (`run_n2sn.yml`) passes.
+
+### Stage 4 - Verify no `rights`-only consumers remain
+- Fleet package-version check confirming the Stage-1 tool is universal.
+- Grep broader infra/config repos for any other consumer reading `rights` from
+  `n2sn_tools.yml`; migrate them.
+- Confirm no deprecation warnings in logs.
+
+### Stage 5 - Drop `rights` from template
+- Remove `rights: *<acronym>_roles` aliases and the anchor names; leave `roles:`
+  only. Deploy fleet-wide; smoke tests confirm.
+
+### Stage 6 - Tighten the tool
+- **Config parser:** drop the `rights` fallback -> hard `RuntimeError` on
+  `rights`-only config.
+- Release final version.
+
+(The CLI wording was already changed to `role`/`ROLE` in Stage 1 and needs no
+further work here.)
+
+## Sequencing summary
+
+| Stage | Repo | Change | Tool reads | Config has |
+|-------|------|--------|-----------|-----------|
+| 1 \|\| 3 | N2SNUserTools | Accept both, prefer `roles`, warn on `rights`; CLI->`role` | both | -- |
+| 1 \|\| 3 | ansible role | Template anchors `roles`, aliases into `rights` | -- | both |
+| 2 | ops | Deploy new tool everywhere | `roles` | both |
+| 4 | ops | Verify no `rights`-only consumers | `roles` | both |
+| 5 | ansible role | Drop `rights` aliases from template | `roles` | `roles` |
+| 6 | N2SNUserTools | Config: hard-fail on `rights`-only | `roles` | `roles` |
+
+**Ordering invariants:**
+- Template drops `rights` (Stage 5) only after the new tool is universal
+  (Stage 2).
+- Tool config parser hard-fails on `rights` (Stage 6) only after the template
+  stops emitting `rights` (Stage 5).
+- Stages 1 and 3 are independent and run in parallel.
+
+## Progress notes
+
+- **Stage 1 (N2SNUserTools) — DONE (pending release):**
+  - Added `import warnings` and `get_roles()` helper in `cli.py`.
+  - Routed all three config reads (`n2sn_list`, and the two in
+    `n2sn_change_user`) through `get_roles()`.
+  - Renamed CLI wording: positional arg `role` / metavar `ROLE`, help/`--purge`
+    text, local var `roles`, validation + output strings (`right`->`role`,
+    `RIGHT`->`ROLE`). The positional argument value has always been a role name
+    (`staff`, `user`, ...), so the rename is transparent to existing callers.
+  - Added a Configuration section to `README.rst` documenting `roles:` and the
+    `rights:` deprecation.
+  - `LDAPInsufficientAccessRightsResult` import left unchanged (correct,
+    different meaning).
+  - Verified with `py_compile` and a unit check of `get_roles()`: roles-only
+    (no warning), rights-only (DeprecationWarning), both (prefers roles, no
+    warning), neither (RuntimeError).
+  - Remaining: bump version / release RPM.
+
+- **Stage 3 (ansible role) — DONE (pending deploy):**
+  - Rewrote `n2sn_tools.yml.j2` so each of the 33 instruments anchors its role
+    mapping under `roles: &<acronym>_roles` and aliases it into
+    `rights: *<acronym>_roles`.
+  - Verified rendered YAML parses with PyYAML `SafeLoader`: all 33 instruments
+    have identical `roles` and `rights`; `fis` typo fix preserved
+    (`n2sn-analysis-fis`); `nyx` extras, `cryoem` reduced set, and `tst`
+    commented-out keys all correct.
+  - Remaining: deploy fleet-wide.
+
+- **Next:** Stage 2 (roll out new tool everywhere) then Stage 4/5/6.

--- a/N2SNUserTools/cli.py
+++ b/N2SNUserTools/cli.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import random
+import warnings
 from os.path import expanduser, basename
 import argparse
 import yaml
@@ -94,6 +95,26 @@ def read_config(parser, instrument=None, no_inst=False):
         return config['common'], None
 
 
+def get_roles(inst_config):
+    """Return the role->group mapping for an instrument config.
+
+    Prefers the ``roles`` key. Falls back to the deprecated ``rights`` key
+    (emitting a ``DeprecationWarning``) for backward compatibility during the
+    ``rights`` -> ``roles`` migration. This fallback will be removed in a
+    future release, at which point a ``rights``-only config will be a hard
+    error.
+    """
+    if 'roles' in inst_config:
+        return inst_config['roles']
+    if 'rights' in inst_config:
+        warnings.warn(
+            "The 'rights' key in n2sn_tools.yml is deprecated; rename it to "
+            "'roles'. Support will be removed in a future release.",
+            DeprecationWarning, stacklevel=2)
+        return inst_config['rights']
+    raise RuntimeError("Instrument config missing 'roles' section")
+
+
 def n2sn_list(desc, message, group_name):
     parser = base_argparser(
         'List current enabled users for an instrument', True
@@ -106,7 +127,7 @@ def n2sn_list(desc, message, group_name):
     print("\n{} for instrument {}\n"
           .format(message, config['name'].upper()))
 
-    groups = config['rights']
+    groups = get_roles(config)
 
     print(n2sn_list_group_users_as_table(
           common_config['server'],
@@ -142,12 +163,12 @@ def n2sn_change_user(operation):
     if operation == 'remove':
         user_group.add_argument(
            '--purge', dest='purge', action='store_true',
-           help='Purge all users from right'
+           help='Purge all users from role'
         )
 
-    parser.add_argument('right', metavar='RIGHT',
+    parser.add_argument('role', metavar='ROLE',
                         type=str,
-                        help='Right to add')
+                        help='Role to add')
 
     args = parser.parse_args()
 
@@ -163,16 +184,17 @@ def n2sn_change_user(operation):
         print(parser.error("You must specify the user by either"
                            " login (username) or life/guest number"))
 
-    att_names = list(inst_config['rights'].keys())
+    roles_map = get_roles(inst_config)
+    att_names = list(roles_map.keys())
 
-    print(set([a.lower() for a in args.right.split(',')]))
+    print(set([a.lower() for a in args.role.split(',')]))
     print(set(att_names))
 
-    rights = args.right.split(',')
+    roles = args.role.split(',')
 
-    if len(set(att_names) & set([a.lower() for a in rights])) \
-       != len(rights):
-        print(parser.error("You must specify a right from the options:"
+    if len(set(att_names) & set([a.lower() for a in roles])) \
+       != len(roles):
+        print(parser.error("You must specify a role from the options:"
                            " {}".format((', '.join(att_names)).upper())))
 
     with ADObjects(common_config['server'],
@@ -182,8 +204,8 @@ def n2sn_change_user(operation):
                    group_search=common_config['group_search'],
                    user_search=common_config['user_search']) as ad:
 
-        for right in rights:
-            group_name = inst_config['rights'][right.lower()]
+        for role in roles:
+            group_name = roles_map[role.lower()]
 
             users = list()
 
@@ -238,9 +260,9 @@ def n2sn_change_user(operation):
                                            "check you have the correct "
                                            "permission.") from None
 
-                    print("\nSuccessfully added right {} to user \"{}\""
+                    print("\nSuccessfully added role {} to user \"{}\""
                           " for instrument {}\n"
-                          .format(right.upper(), user['displayName'],
+                          .format(role.upper(), user['displayName'],
                                   inst_config['name'].upper()))
 
                 if (operation == "remove") and (args.purge is False):
@@ -253,9 +275,9 @@ def n2sn_change_user(operation):
                                            "check you have the correct "
                                            "permission.") from None
 
-                    print("\nSuccessfully removed right {} from user \"{}\""
+                    print("\nSuccessfully removed role {} from user \"{}\""
                           " for instrument {}"
-                          .format(right.upper(), user['displayName'],
+                          .format(role.upper(), user['displayName'],
                                   inst_config['name'].upper()))
 
                 if (operation == "remove") and (args.purge is True):
@@ -276,9 +298,9 @@ def n2sn_change_user(operation):
                                            "permission.") from None
 
                     print("\nSuccessfully removed all users"
-                          " for instrument {} with right '{}'\n"
+                          " for instrument {} with role '{}'\n"
                           .format(inst_config['name'].upper(),
-                                  right.upper()))
+                                  role.upper()))
 
 
 def n2sn_add_user():

--- a/README.rst
+++ b/README.rst
@@ -5,6 +5,32 @@ N2SN User Tools
 NSLS-II N2SN User Manipulation Tools for Python
 
 
+Configuration
+*************
+
+The tools read a YAML configuration file from either
+``~/.config/n2sn_tools.yml`` or ``/etc/n2sn_tools.yml``. Each instrument
+defines a ``roles`` mapping of role name to the Active Directory group that
+implements that role::
+
+    instruments:
+      xpd:
+        name: XPD
+        roles:
+          staff: n2sn-inststaff-xpd
+          user: n2sn-instusers-xpd
+
+These Active Directory groups contain users directly and are *role* groups in
+the NSLS-II RBAC model.
+
+.. note::
+
+   The ``roles`` key was previously named ``rights``. The ``rights`` key is
+   deprecated and still accepted for backward compatibility (with a
+   ``DeprecationWarning``), but support will be removed in a future release.
+   Update configuration files to use ``roles``.
+
+
 Reporting issues
 ****************
 


### PR DESCRIPTION
Why trying to understand the chain of AD groups for configuring guacamole I realized that the naming in this tool was not consistent with the definitions in RBAC.  This (along with a PR to ansible) will fix that.